### PR TITLE
fix: remove dependency on tensorboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,10 @@ scipy>=1.4.1
 torch>=1.7.0,!=1.12.0
 torchvision>=0.8.1,!=0.13.0
 tqdm>=4.41.0
-protobuf<4.21.3
+# protobuf<4.21.3
 
 # Logging -------------------------------------
-tensorboard>=2.4.1
+# tensorboard>=2.4.1
 # wandb
 
 # Plotting ------------------------------------
@@ -27,13 +27,3 @@ seaborn>=0.11.0
 # tensorflow>=2.4.1  # TFLite export
 # tensorflowjs>=3.9.0  # TF.js export
 # openvino-dev  # OpenVINO export
-
-# Extras --------------------------------------
-ipython  # interactive notebook
-psutil  # system utilization
-thop  # FLOPs computation
-# albumentations>=1.0.3
-# pycocotools>=2.0  # COCO mAP
-# roboflow
-# huggingface
-huggingface-hub>=0.11.1


### PR DESCRIPTION
Since we are using yolov7 for inference at the moment. We will disable tensorboard related dependecies for now.